### PR TITLE
Handle underscores in attachment field name

### DIFF
--- a/src/Codesleeve/LaravelStapler/Commands/FastenCommand.php
+++ b/src/Codesleeve/LaravelStapler/Commands/FastenCommand.php
@@ -78,7 +78,7 @@ class FastenCommand extends Command
 		if (!is_dir($path)) mkdir($path);
 
 		$fileName  = $path . '/' . $prefix . '_add_' . $data['attachment'] . '_fields_to_' . $data['table'] . '_table.php';
-		$data['className'] = 'Add' . ucfirst($data['attachment']) . 'FieldsTo' . ucfirst(Str::camel($data['table'])) . 'Table';
+		$data['className'] = 'Add' . ucfirst(Str::camel($data['attachment'])) . 'FieldsTo' . ucfirst(Str::camel($data['table'])) . 'Table';
 
 		// Save the new migration to disk using the stapler migration view.
 		$migration = View::make('laravel-stapler::migration', $data)->render();


### PR DESCRIPTION
Classname of migration will be invalid w/o Str::camel()
