### PR TITLE
Add progress report to refresh service

### DIFF
--- a/src/Commands/RefreshCommand.php
+++ b/src/Commands/RefreshCommand.php
@@ -49,6 +49,8 @@ class RefreshCommand extends Command
 	 */
 	public function fire()
 	{
+		$this->imageRefreshService->setOutput($this->output);
+
 		$class = $this->argument('class');
 		$attachments = $this->option('attachments') ?: [];
 


### PR DESCRIPTION
This adds the possibility for the ImageRefreshService to be passed an implementation of OutputInterface to allow it to display progress when running. This doesn't couple the service to the command as it's entirely facultative.

The benefit is huge as the command currently just prints "Refreshing uploaded images..." and can hang for a long while depending on your number of models/attachments. This allows the user to see the progress and additionally see which entry is culprit when an exception is being thrown (file not found, etc.)

Example output:

```bash
Refreshing uploaded images...
    5/3459 [>---------------------------]   0%  1 sec/12 mins 87.5 MiB
```