### PR TITLE
Remove array type from attribute

### DIFF
--- a/src/Services/ImageRefreshService.php
+++ b/src/Services/ImageRefreshService.php
@@ -46,7 +46,7 @@ class ImageRefreshService
      * @param  array $attachments
      * @return void
      */
-    public function refresh($class, array $attachments)
+    public function refresh($class, $attachments)
     {
         if (!method_exists($class, 'hasAttachedFile')) {
             throw new InvalidClassException("Invalid class: the $class class is not currently using Stapler.", 1);


### PR DESCRIPTION
`refresh` was expecting an array but was always passed a string