### PR TITLE
Fix missing Commands namespace for FastenCommand

### DIFF
--- a/src/LaravelStaplerServiceProvider.php
+++ b/src/LaravelStaplerServiceProvider.php
@@ -92,7 +92,7 @@ class LaravelStaplerServiceProvider extends ServiceProvider
         {
             $migrationsFolderPath = app_path() . '/database/migrations';
 
-            return new FastenCommand($app['view'], $app['files'], $migrationsFolderPath);
+            return new Commands\FastenCommand($app['view'], $app['files'], $migrationsFolderPath);
         });
     }
 


### PR DESCRIPTION
This prevents the package from being installed as per the instructions.