### PR TITLE
Fix for "Class 'Codesleeve\LaravelStapler\FastenCommand' not found"

### DIFF
--- a/src/LaravelStaplerServiceProvider.php
+++ b/src/LaravelStaplerServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Codesleeve\LaravelStapler;
 
+use Codesleeve\LaravelStapler\Commands\FastenCommand;
 use Config;
 use Illuminate\Support\ServiceProvider;
 use Codesleeve\LaravelStapler\Services\ImageRefreshService;


### PR DESCRIPTION
Fix for this error using "Use" expression. 