### PR TITLE
Wrap S3 Credentials in a Key

### DIFF
--- a/src/config/s3.php
+++ b/src/config/s3.php
@@ -13,8 +13,10 @@ return [
     |
     */
     's3_client_config' => [
-        'key' => '',
-        'secret' => '',
+        'credentials' => [
+            'key' => '',
+            'secret' => ''
+        ],
         'region' => '',
         'scheme' => 'http'
     ],


### PR DESCRIPTION
The AWS SDK now expects credentials to be in a separate key among the configuration key/values passed during instantiation. For this fix to work properly, validateS3Options must also be updated in Codesleeve\Stapler\Validator