### PR TITLE
Reimplemented defaults => placeholders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "codesleeve/stapler": "1.0.*",
+        "codesleeve/stapler": "dev-master",
         "laravel/framework": "4.*|5.*"
     },
     "autoload": {

--- a/src/LaravelStaplerServiceProvider.php
+++ b/src/LaravelStaplerServiceProvider.php
@@ -73,6 +73,10 @@ class LaravelStaplerServiceProvider extends ServiceProvider
         $config = new IlluminateConfig(Config::getFacadeRoot(), 'laravel-stapler');
         Stapler::setConfigInstance($config);
 
+        if ($placeholder = $config->get('stapler.placeholder')) {
+            Stapler::setPlaceholderInstance(new $placeholder);   
+        }
+
         if (!$config->get('stapler.public_path')) {
             $config->set('stapler.public_path', realpath(public_path()));
         }

--- a/src/Providers/L4ServiceProvider.php
+++ b/src/Providers/L4ServiceProvider.php
@@ -51,6 +51,10 @@ class L4ServiceProvider extends ServiceProvider
         $config = new IlluminateConfig(Config::getFacadeRoot(), 'laravel-stapler');
         Stapler::setConfigInstance($config);
 
+        if ($placeholder = $config->get('stapler.placeholder')) {
+            Stapler::setPlaceholderInstance(new $placeholder);   
+        }
+
         if (!$config->get('stapler.public_path')) {
             $config->set('stapler.public_path', realpath(public_path()));
         }

--- a/src/Providers/L5ServiceProvider.php
+++ b/src/Providers/L5ServiceProvider.php
@@ -56,6 +56,10 @@ class L5ServiceProvider extends ServiceProvider
         $config = new IlluminateConfig(Config::getFacadeRoot(), 'laravel-stapler', '.');
         Stapler::setConfigInstance($config);
 
+        if ($placeholder = $config->get('stapler.placeholder')) {
+            Stapler::setPlaceholderInstance(new $placeholder);   
+        }
+
         if (!$config->get('stapler.public_path')) {
             $config->set('stapler.public_path', realpath(public_path()));
         }

--- a/src/config/stapler.php
+++ b/src/config/stapler.php
@@ -51,30 +51,42 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Stapler Default Url
+    | Stapler Placeholder Class
     |--------------------------------------------------------------------------
     |
-    | The url (relative to your project document root) containing a default image
-    | that will be used for attachments that don't currently have an uploaded image
-    | attached to them.
+    | The class used to generate placeholders for attachments that don't 
+    | currently have an uploaded image attached to them.
     |
     */
 
-    'default_url' => '/:attachment/:style/missing.png',
+    'placeholder' => null,
 
     /*
     |--------------------------------------------------------------------------
-    | Stapler Default Style
+    | Stapler Placeholder Url
     |--------------------------------------------------------------------------
     |
-    | The default style returned from the Stapler file location helper methods.
-    | An unaltered version of uploaded file is always stored within the 'original'
-    | style, however the default_style can be set to point to any of the defined
-    | styles within the styles array.
+    | The url (relative to your project document root) containing a placeholder
+    | image that will be used for attachments that don't currently have an
+    | uploaded image attached to them.
     |
     */
 
-    'default_style' => 'original',
+    'placeholder_url' => '/:attachment/:style/missing.png',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stapler Placeholder Style
+    |--------------------------------------------------------------------------
+    |
+    | The placeholder style returned from the Stapler file location helper
+    | methods. An unaltered version of uploaded file is always stored within
+    | the 'original' style, however the placeholder_style can be set to point
+    | to any of the defined styles within the styles array.
+    |
+    */
+
+    'placeholder_style' => 'original',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Previously defaults could only be static images.

I wanted to support having autogenerated avatars that are unique for every user. In order to support this I "needed" to be able to change the defaults behavior.

For this reason I renamed defaults to placeholders and moved it out into it's own file that anyone can replace.

So now in my app I will write my own Placeholder and change the placeholder class in the cofig to mine. My placeholder class will then autogenerate an avatar for the model and attach it to the model.
