### PR TITLE
Use use Illuminate\Contracts\Config\Repository

### DIFF
--- a/src/IlluminateConfig.php
+++ b/src/IlluminateConfig.php
@@ -3,7 +3,7 @@
 namespace Codesleeve\LaravelStapler;
 
 use Codesleeve\Stapler\Interfaces\Config;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 
 class IlluminateConfig implements Config
 {


### PR DESCRIPTION
This way the library can be used alongside with cms like OctoberCMS that
change the Config instantiation but still use the Config Contract