### PR TITLE
Fixes call to singleton() in registerImageRefreshService() for Laravel 5.4

### DIFF
--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -55,7 +55,7 @@ abstract class ServiceProvider extends BaseServiceProvider
      */
     protected function registerImageRefreshService()
     {
-        $this->app->singleton('ImageRefreshService', function ($app, $params) {
+        $this->app->singleton('ImageRefreshService', function ($app) {
             return new ImageRefreshService($app);
         });
     }


### PR DESCRIPTION
Laravel 5.4 no longer accepts a second parameter to the container's `make` method causing this package to throw an error during `composer install` in a Laravel 5.4 app. 

From [the Laravel 5.4 upgrade guide](https://laravel.com/docs/5.4/upgrade#upgrade-5.4.0):

> _"The container's `make` method no longer accepts a second array of parameters. This feature typically indicates a code smell. Typically, you can always construct the object in another way that is more intuitive."_

As `Codesleeve\LaravelStapler\Providers\ServiceProvider::registerImageRefreshService()` doesn't actually use the `$params` argument, I think we can safely remove it.

For reference, here's the error thrown by Composer:

```
> Illuminate\Foundation\ComposerScripts::postUpdate
> php artisan optimize
                           
  [Symfony\Component\Debug\Exception\FatalThrowableError]                      
  Type error: Too few arguments to function Codesleeve\LaravelStapler\Provide  
  rs\ServiceProvider::Codesleeve\LaravelStapler\Providers\{closure}(), 1 pass  
  ed in /Users/harrison/Sites/countryside-classroom/vendor/laravel/framework/  
  src/Illuminate/Container/Container.php on line 678 and exactly 2 expected   
```

![screen shot 2017-02-01 at 11 22 31](https://cloud.githubusercontent.com/assets/377366/22504969/d3fc0278-e870-11e6-9624-dd541f417f8d.jpg)
